### PR TITLE
replace pushstate event with chained effect

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,4 +1,4 @@
-import { LoadBundle, ChangeLocation } from './effects'
+import { LoadBundle, UpdateHistory } from './effects'
 
 import { getPathInfo } from './utils'
 
@@ -55,10 +55,9 @@ const BundleLoaded = (state, { path, bundle }) => {
 }
 
 // Navigate action
-export const Navigate = (state, to) => [
-  state,
-  ChangeLocation({ to })
-]
+export const Navigate = (state, to) => window.location.pathname === to
+  ? state
+  : [ParseUrl(state, to), UpdateHistory({ to })]
 
 export const TriggerPageLoadIfGoodConnection = (state, path) => {
   if (state.goodConnection) {

--- a/src/effects.js
+++ b/src/effects.js
@@ -11,11 +11,7 @@ const loadBundleFx = (dispatch, { action, bundlePromise, path }) =>
 export const LoadBundle = ({ action, bundlePromise, path }) => [loadBundleFx, { action, bundlePromise, path }]
 
 // Change location FX
-const locationFx = (dispatch, { to }) => {
-  if (to !== window.location.pathname) {
-    // window.scrollTo(0, 0)
-    history.pushState(null, '', to)
-    dispatchEvent(new CustomEvent('pushstate'))
-  }
+const historyFx = (dispatch, { to }) => {
+  history.pushState(null, '', to)
 }
-export const ChangeLocation = ({ to }) => [locationFx, { to }]
+export const UpdateHistory = ({ to }) => [historyFx, { to }]

--- a/src/hyperstatic.js
+++ b/src/hyperstatic.js
@@ -1,5 +1,5 @@
 import { app } from 'hyperapp'
-import { LocationChanged } from './subscriptions'
+import { PopState } from './subscriptions'
 import { ParseUrl } from './actions'
 import { buildRoutesObject } from './buildRoutesObject'
 
@@ -31,7 +31,7 @@ export const hyperstatic = ({ routes, init: userInit, view, subscriptions: userS
       const subs = userSubs ? userSubs(state) : []
 
       return subs.concat([
-        LocationChanged({ action: ParseUrl })
+        PopState({ action: ParseUrl })
       ])
     },
     node

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -1,14 +1,12 @@
 
-// LocationChanged Subscription
+// PopState Subscription
 const subFx = a => b => [a, b]
-export const LocationChanged = subFx((dispatch, props) => {
+export const PopState = subFx((dispatch, props) => {
   const handleLocationChange = ev => {
     dispatch([props.action, window.location.pathname + window.location.search])
   }
-  addEventListener('pushstate', handleLocationChange)
   addEventListener('popstate', handleLocationChange)
   return () => {
-    removeEventListener('pushstate', handleLocationChange)
     removeEventListener('popstate', handleLocationChange)
   }
 })


### PR DESCRIPTION
Hello again,

I've been looking into more ways to optimize Hyperstatic, and I while this is a small change I think it reduces code complexity in a good way. While the `popstate` event is fired by the browser (on browser back button), `pushstate` is only fired by the `ChangeLocation` effect. Instead of firing the event in the effect, I think it is a lot more clear to use the `ParseUrl` action in `Navigate` and only have the `ChangeLocation` effect update the `history`.

This PR is probably a little more opinionated than the last one (especially with function names), and I'm willing to make any changes you suggest. 