### PR TITLE
Revert "replace manual object mapping with Object.values"

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -17,7 +17,8 @@ export const ParseUrl = (state, path) => {
 }
 
 const BundleLoaded = (state, { path, bundle }) => {
-  const matchedRoute = Object.values(state.routes).find(route => route.pattern.match(path))
+  const routes = Object.keys(state.routes).map(route => state.routes[route])
+  const matchedRoute = routes.find(route => route.pattern.match(path))
 
   const withBundleLoaded = {
     ...state,
@@ -67,7 +68,8 @@ export const TriggerPageLoadIfGoodConnection = (state, path) => {
 }
 
 export const TriggerPageLoad = (state, path) => {
-  const matchedRoute = Object.values(state.routes).find(route => route.pattern.match(path))
+  const routes = Object.keys(state.routes).map(route => state.routes[route])
+  const matchedRoute = routes.find(route => route.pattern.match(path))
 
   const pageData = state.pageData[path]
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,8 @@ export const getPathInfo = (state, path) => {
 
   // Ignore trailing slashes EXPEPT for home page
   const withoutTrailingSlash = pathname !== '/' ? pathname.replace(/\/$/, '') : pathname
-  const matchedRoute = Object.values(state.routes).find(route => route.pattern.match(withoutTrailingSlash))
+  const routes = Object.keys(state.routes).map(route => state.routes[route])
+  const matchedRoute = routes.find(route => route.pattern.match(withoutTrailingSlash))
   const matchParams = matchedRoute && matchedRoute.pattern.match(withoutTrailingSlash)
   const loaded = matchedRoute && matchedRoute.view
 


### PR DESCRIPTION
Reverts loteoo/hyperstatic#11

Unfortunately browser support isn't quite there yet, and it isn't transpiled by babel yet... I prefer reverting than managing a polyfill