### PR TITLE
Feature/add dist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hyperapp static site framework",
   "author": "Alexandre Lotte",
   "license": "MIT",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "module": "src/index.js",
   "scripts": {
     "build": "parcel build ./src/index.js",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "src/index.js",
   "module": "src/index.js",
   "scripts": {
+    "build": "parcel build ./src/index.js",
     "test": "echo \"No test specified\""
   },
   "dependencies": {


### PR DESCRIPTION
Related issue: https://github.com/loteoo/hyperstatic/issues/14

@mdings Hey I removed the usage of Object.fromEntries while it gets more browser support.

I updated the entrypoint of the package to use a production bundle generated by parcel