### PR TITLE
Update puppeteer options to work in WSL

### DIFF
--- a/src/renderPages.js
+++ b/src/renderPages.js
@@ -20,7 +20,10 @@ const renderPages = async (allPages, port = 54321) => {
 
   const baseUrl = `http://localhost:${port}`
 
-  const browser = await puppeteer.launch({ args: ['--no-sandbox'] })
+  const browser = await puppeteer.launch({
+    ignoreDefaultArgs: ['--disable-extensions'],
+    args: ['--no-sandbox', '--single-process']
+  })
 
   console.log(`Rendering ${allPages.length} pages...`)
 


### PR DESCRIPTION
Puppeteer doesn't work with the defaults under WSL, see issue and workaround here:

https://github.com/puppeteer/puppeteer/issues/1837#issuecomment-545551412

This change has been successfully tested in WSL and mac, as well as used in a netlify deploy.