### PR TITLE
Replace .replace(...) with .split(...).join('')

### DIFF
--- a/src/renderPages.js
+++ b/src/renderPages.js
@@ -53,7 +53,7 @@ const renderPages = async (allPages, port = 54321) => {
 
     // Remove basepath from rendered HTML
     // Ex: <script src="http://localhost/about" /> becomes just <script src="/about" />
-    const cleanedUpHtml = html.replace(baseUrl, '')
+    const cleanedUpHtml = html.split(baseUrl).join('')
 
     try {
       await fse.outputFile(pageFileAbsolutePath, cleanedUpHtml)


### PR DESCRIPTION
`string.replace(...)` only replaces the first match when the pattern is a literal string (as opposed to a regular expression), see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace

This patch uses `string.split(...).join('')` instead to ensure all instances of baseUrl are correctly removed from rendered pages.

An alternative could be to convert the pattern to a regular expression and use the 'g' flag:

```javascript
const cleanedUpHtml = html.replace(new RegExp(baseUrl, 'g'), '')
```

However I think this version is simpler and clearer.