### PR TITLE
replaces all occurrences of base path

### DIFF
--- a/src/renderPages.js
+++ b/src/renderPages.js
@@ -56,7 +56,8 @@ const renderPages = async (allPages, port = 54321) => {
 
     // Remove basepath from rendered HTML
     // Ex: <script src="http://localhost/about" /> becomes just <script src="/about" />
-    const cleanedUpHtml = html.split(baseUrl).join('')
+    const cleanedUpHtml = html.replace(new RegExp(baseUrl, 'gi'), '')
+    
 
     try {
       await fse.outputFile(pageFileAbsolutePath, cleanedUpHtml)


### PR DESCRIPTION
I noticed that as per this PR https://github.com/loteoo/hyperstatic/pull/21 still not all occurrences are being replaced. Using a regex will solve this issue as also proposed in the comments