### PR TITLE
Allow for optional `node` parameter to hyperstatic's main function.

### DIFF
--- a/src/hyperstatic.ts
+++ b/src/hyperstatic.ts
@@ -11,7 +11,7 @@ import { Config, LocationState, Options, State } from './types';
 
 
 
-const hyperstatic = ({ routes, options: userOptions, init, view, subscriptions = (_s) => [], ...rest }: Config) => {
+const hyperstatic = ({ node, routes, options: userOptions, init, view, subscriptions = (_s) => [], ...rest }: Config) => {
 
   const options: Options = {
     eagerLoad: true,
@@ -100,7 +100,7 @@ const hyperstatic = ({ routes, options: userOptions, init, view, subscriptions =
     init: initAction,
     view: (state) => provide(
       { state, meta, options, getLocation, PreloadPage },
-      h('div', { id: 'hyperstatic' }, view(state))
+      h('div', { id: node ? node : 'hyperstatic' }, view(state))
     ),
     subscriptions: (state) => [
       ...subscriptions(state),
@@ -112,7 +112,7 @@ const hyperstatic = ({ routes, options: userOptions, init, view, subscriptions =
         action: PreloadPage
       })
     ],
-    node: document.getElementById('hyperstatic'),
+    node: document.getElementById(node ? node : 'hyperstatic'),
   })
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface Options {
 }
 
 export interface Config {
+  node?: string;
   routes: Record<string, Promise<any> | any>;
   options?: Options;
   init: Record<string, any>;


### PR DESCRIPTION
While I understand the convenience of everything "just working" by providing a div with a "hyperapp" ID, I feel it would allow more people to use hyperapp/hyperstatic if we allow a node to be passed in.

This would allow hyperapp/hyperstatic to be gradually adopted into a project by allowing certain nodes to be taken over by it, rather than limiting it to one.

I've allowed the node to be optional, giving backwards compatability to the previous hyperstatic version.

Interested to hear your thoughts on this, and apologies if I made any mistakes in this pull request!